### PR TITLE
ページ上の店舗情報表示

### DIFF
--- a/src/app/Http/Controllers/StoreInformationController.php
+++ b/src/app/Http/Controllers/StoreInformationController.php
@@ -3,11 +3,21 @@
 namespace App\Http\Controllers;
 
 use Illuminate\Http\Request;
+use App\Models\Shop;
+use App\Models\Area;
+use App\Models\Genre;
+
 
 class StoreInformationController extends Controller
 {
     public function index()
     {
-        return view('shop_all');
+        // $shops = Shop::all();
+        // foreach($shops as $shop) {
+        //     $$shops = $shop->area;
+        // }
+        $shops = Shop::with('area','genre')->get();
+        // dd($shops);
+        return view('shop_all', compact('shops'));
     }
 }

--- a/src/app/Models/Area.php
+++ b/src/app/Models/Area.php
@@ -13,7 +13,7 @@ class Area extends Model
         'name',
     ];
 
-    public function shop()
+    public function shops()
     {
         return $this->hasMany(Shop::class);
     }

--- a/src/resources/views/shop_all.blade.php
+++ b/src/resources/views/shop_all.blade.php
@@ -11,11 +11,13 @@
 
 @section('content')
 <div>
+    
+    @foreach($shops as $shop)
     <div>
-        <img>
-        <p>仙人</p>
-        <p>#エリア</p>
-        <P>#ジャンル</P>
+        <img src="{{$shop['shop_image']}}" width="200" height="150">
+        <p>{{$shop['store_name']}}</p>
+        <p>#{{$shop->area['name']}}</p>
+        <P>#{{$shop->genre['name']}}</P>
         <form action="" method="get">
             <input type="submit" name="" value="詳しく見る">
         </form>
@@ -23,5 +25,6 @@
             <input type="submit" name="" value="お気に入りボタン(仮定)">
         </form>
     </div>
+    @endforeach
 </div>
 @endsection

--- a/src/routes/web.php
+++ b/src/routes/web.php
@@ -14,7 +14,8 @@ use App\Http\Controllers\StoreInformationController;
 | contains the "web" middleware group. Now create something great!
 |
 */
-Route::middleware('auth')->group(function () {
 Route::get('/', [StoreInformationController::class, 'index']);
-});
+// Route::middleware('auth')->group(function () {
+// Route::get('/', [StoreInformationController::class, 'index']);
+// });
 


### PR DESCRIPTION
店舗情報のデータベースから情報を抜き出し、ページ上の表示を出力する処理を追加しました。これから’詳しく見る’ボタンを押すと詳細ページを表示する処理を付け加えていきます。