### PR TITLE
認証切れ時のログイン画面移動

### DIFF
--- a/src/routes/web.php
+++ b/src/routes/web.php
@@ -20,7 +20,7 @@ Route::post('/reservation', [StoreInformationController::class, 'reservation'])-
 Route::get('/done', function(){return view('done');});
 Route::get('/my_page', [UserInformationController::class, 'my_page'])->name('my_page')->middleware('auth');
 Route::get('/delete_reservation', [UserInformationController::class, 'delete_reservation']);
-Route::get('/favorite', [UserInformationController::class,'favorite']);
+Route::get('/favorite', [UserInformationController::class,'favorite'])->middleware('auth');
 // Route::middleware('auth')->group(function () {
 // Route::get('/', [StoreInformationController::class, 'index']);
 // });


### PR DESCRIPTION
認証切れのときにお気に入りボタンを押すとエラー画面になってしまうので、authミドルウェアを適応させ、ログイン画面に切り替えるよう修正しました。