### PR TITLE
mailableクラスの作成

### DIFF
--- a/src/app/Mail/Identification.php
+++ b/src/app/Mail/Identification.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace App\Mail;
+
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Mail\Mailable;
+use Illuminate\Queue\SerializesModels;
+
+class Identification extends Mailable
+{
+    use Queueable, SerializesModels;
+
+    /**
+     * Create a new message instance.
+     *
+     * @return void
+     */
+    public function __construct()
+    {
+        //
+    }
+
+    /**
+     * Build the message.
+     *
+     * @return $this
+     */
+    public function build()
+    {
+        return $this->view('email.identification');
+    }
+}


### PR DESCRIPTION
メール送信ができているかmailtrapを使用して送信メールのテストをmail関数で行ってみましたが、php.iniに細かい設定が必要そうなのでmailableクラスを使用していくことにしました。
同時に新規登録時のメール確認用のviewファイルを作成しました。中身は殆どかけてない状態です。